### PR TITLE
Feature: specify env variables that should be passed on to buildah at build time

### DIFF
--- a/.update_requirements.sh
+++ b/.update_requirements.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Updating requirements.txt and requirements_dev.txt"
+pip-compile > requirements.txt
+pip-compile requirements_dev.in
+sed -ie 's/^--find-links.*//' requirements*.txt
+
+echo Done\!
+echo 'You can now run (in bash)'
+echo 'pip-sync requirements_dev.txt requirements.txt <(echo -- '-e' . )'
+echo to update your local environment

--- a/derex/builder/builders/schema.py
+++ b/derex/builder/builders/schema.py
@@ -15,6 +15,7 @@ pointer = {
 BASE_PROPERTIES = {
     "builder": {"type": "object", "properties": {"class": {"type": "string"}}},
     "dest": {"type": "string"},
+    "build_env": {"type": "array", "items": {"type": "string"}},
     "config": {
         "type": "object",
         "additionalProperties": False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,20 @@
 #
 #    pip-compile
 #
+
+
 attrs==19.1.0             # via jsonschema
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2
 click==7.0
-docker-pycreds==0.4.0     # via docker
-docker==3.7.2
+docker==4.0.1
 idna==2.8                 # via requests
 jsonschema==3.0.1
 pyrsistent==0.15.2        # via jsonschema
 pyyaml==5.1
-requests==2.21.0          # via docker
-six==1.12.0               # via docker, docker-pycreds, jsonschema, pyrsistent, websocket-client
-urllib3==1.24.3           # via requests
+requests==2.22.0          # via docker
+six==1.12.0               # via docker, jsonschema, pyrsistent, websocket-client
+urllib3==1.25.3           # via requests
 websocket-client==0.56.0  # via docker
 zope.dottedname==4.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,15 +4,17 @@
 #
 #    pip-compile requirements_dev.in
 #
+
+
 alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via black
-aspy.yaml==1.2.0          # via pre-commit
+aspy.yaml==1.3.0          # via pre-commit
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via black, pytest
-babel==2.6.0              # via sphinx
+babel==2.7.0              # via sphinx
 black==19.3b0
 certifi==2019.3.9         # via requests
-cfgv==1.6.0               # via pre-commit
+cfgv==2.0.0               # via pre-commit
 chardet==3.0.4            # via requests
 click==7.0                # via black, pip-tools
 coverage==4.5.3
@@ -22,7 +24,7 @@ flake8==3.7.7
 identify==1.4.3           # via pre-commit
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.13  # via pre-commit
+importlib-metadata==0.17  # via pluggy, pre-commit, pytest
 importlib-resources==1.0.2  # via pre-commit
 isort==4.3.20
 jinja2==2.10.1            # via sphinx
@@ -32,26 +34,26 @@ more-itertools==7.0.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
 mypy==0.701
 nodeenv==1.3.3            # via pre-commit
-packaging==19.0           # via sphinx
+packaging==19.0           # via pytest, sphinx
 pip-tools==3.7.0
-pluggy==0.11.0            # via pytest
+pluggy==0.12.0            # via pytest
 pre-commit==1.16.1
 py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
-pygments==2.4.0           # via sphinx
+pygments==2.4.2           # via sphinx
 pyparsing==2.4.0          # via packaging
 git+https://github.com/Abstract-Tech/pytest-black.git#egg=pytest-black
 pytest-cov==2.7.1
 git+https://github.com/Abstract-Tech/pytest-flake8.git#egg=pytest-flake8
 pytest-mock==1.10.4
-pytest==4.5.0
+pytest==4.6.1
 pytz==2019.1              # via babel
 pyyaml==5.1               # via aspy.yaml, pre-commit
 requests==2.22.0          # via sphinx
 six==1.12.0               # via cfgv, packaging, pip-tools, pre-commit, pytest
 snowballstemmer==1.2.1    # via sphinx
-sphinx==2.0.1
+sphinx==2.1.0
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
@@ -60,7 +62,7 @@ sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 toml==0.10.0              # via black, pre-commit
 typed-ast==1.3.5          # via mypy
-urllib3==1.25.2           # via requests
+urllib3==1.25.3           # via requests
 virtualenv==16.6.0        # via pre-commit
 wcwidth==0.1.7            # via pytest
 wheel==0.33.4

--- a/tests/builders/base/dump_var.sh
+++ b/tests/builders/base/dump_var.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$BUILD_VAR" > /build_var.txt

--- a/tests/builders/base/spec.yml
+++ b/tests/builders/base/spec.yml
@@ -9,6 +9,10 @@ copy:
 
 scripts:
   - hello_world.sh
+  - dump_var.sh
+
+build_env:
+  - BUILD_VAR
 
 config:
   entrypoint: '["/entrypoint.sh"]'


### PR DESCRIPTION
Adds a `build_env` configuration to enumerate variable names that should be looked up during build and, if defined, passed to the buildah run commands. Uses `buildah config` to accomplish that.